### PR TITLE
connector: fix Yahboom ST7701 backlight polarity

### DIFF
--- a/kernel/connector/src/panels/mipi_st7701.c
+++ b/kernel/connector/src/panels/mipi_st7701.c
@@ -769,7 +769,7 @@ static const struct panel_desc st7701_480x640_yahboom_panel_desc = {
         .reset_delay_ms = 10,
         .backlight_delay_ms = 0,
         .reset_active_low = K_TRUE,
-        .backlight_active_low = K_FALSE,
+        .backlight_active_low = K_TRUE,
     },
 
     .bus.dsi = {


### PR DESCRIPTION
## Summary
- fix the Yahboom ST7701 backlight polarity setting
- keep the panel backlight enabled after boot instead of flashing briefly and going dark

## Validation
- confirmed the panel path uses the Yahboom-specific ST7701 descriptor
- built the Yahboom image successfully after the fix